### PR TITLE
Use version range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "ephem==4.2.1"
+    "ephem>=4.2,<5.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
Was there a reason for the exact pinning? Usually dependencies for publicly available libraries use ranges.

I'd suggest to loosen the restrictive pinning. I also use renovate and because of this restriction I couldn't update `ephem` in my codebase.

